### PR TITLE
fix: correct merge_queue_grouping_strategy typo and remove deprecated var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Use this section to track upcoming changes, to let people see what changes they might expect in
-upcoming releases.
+### Fixed
 
-At release time, move the entries from here to a new release section.
+- Corrected typo in `merge_queue_grouping_strategy` default value (from `ALLGAIN` to `ALLGREEN`).
+
+### Removed
+
+- Removed deprecated `ignore_vulnerability_alerts_during_read` variable and argument.
 
 ## [1.4.1] - 2026-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Use this section to track upcoming changes, to let people see what changes they might expect in
+upcoming releases.
+
+At release time, move the entries from here to a new release section.
+
+## [1.4.2] - 2026-03-10
+
 ### Fixed
 
 - Corrected typo in `merge_queue_grouping_strategy` default value (from `ALLGAIN` to `ALLGREEN`).

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,6 @@ resource "github_repository" "this" {
   has_projects                            = var.has_projects
   has_wiki                                = var.has_wiki
   homepage_url                            = var.homepage_url
-  ignore_vulnerability_alerts_during_read = var.ignore_vulnerability_alerts_during_read
   is_template                             = var.is_template
   license_template                        = var.license_template
   merge_commit_message                    = var.merge_commit_message

--- a/variables.tf
+++ b/variables.tf
@@ -117,12 +117,6 @@ variable "homepage_url" {
   default     = null
 }
 
-variable "ignore_vulnerability_alerts_during_read" {
-  description = "Set to true to not call the vulnerability alerts endpoint so the resource can also be used without admin permissions during read."
-  type        = bool
-  default     = true # Resource default is false, but we prefer true
-}
-
 variable "is_template" {
   description = "Set to true to tell GitHub that this is a template repository."
   type        = bool
@@ -160,9 +154,9 @@ variable "merge_queue_enabled" {
 }
 
 variable "merge_queue_grouping_strategy" {
-  description = "The grouping strategy to use for the merge queue. Defaults to \"ALLGAIN\"."
+  description = "The grouping strategy to use for the merge queue. Defaults to \"ALLGREEN\"."
   type        = string
-  default     = "ALLGAIN"
+  default     = "ALLGREEN"
 }
 
 variable "merge_queue_max_entries_to_build" {


### PR DESCRIPTION
This PR was generated by Aerith.

**Slack Context:** [Link to Slack Thread](https://footprintitsolutions.slack.com/archives/C0A2AQNF6SY/p1773133897077849)

**Task ID:** f935b5f1-4caa-4be9-ad3b-682cb2b14347

### Description

This PR fixes a typo in the default value of `merge_queue_grouping_strategy` (from `ALLGAIN` to `ALLGREEN`), which was causing planning failures. 

It also removes the deprecated `ignore_vulnerability_alerts_during_read` variable and argument, tidying up the technical debt and resolving the numerous deprecation warnings observed in recent CI runs.